### PR TITLE
Fix anchor/hash part of link

### DIFF
--- a/narrative-schemas/README.md
+++ b/narrative-schemas/README.md
@@ -1,3 +1,3 @@
 # Narrative Schemas
 
-This folder contains a few examples of [_narrative schemas_](../documents/README.md#narrative-schemas), which can be linked to litvis documents.
+This folder contains a few examples of [_narrative schemas_](../documents/README.md#6-narrative-schemas), which can be linked to litvis documents.


### PR DESCRIPTION
The hash/anchor part of this link is wrong, so clicking the link takes the reader to the top of the `README` file rather than to the `Narrative schemas` subsection.