### PR TITLE
Interactive by default and archive keyword in codeBlock

### DIFF
--- a/packages/litvis-integration-mume/src/renderEnhancers/literateElm.ts
+++ b/packages/litvis-integration-mume/src/renderEnhancers/literateElm.ts
@@ -143,6 +143,7 @@ export default async function enhance(
     const outputFormat: OutputFormat | undefined = $el.data("outputFormat");
     const expressionText = $el.data("expression");
     const interactive = $el.data("interactive");
+    const archive = $el.data("archive");
     const renderKey = hash({
       contextName,
       outputFormat,
@@ -232,7 +233,7 @@ export default async function enhance(
           resultNormalizedInfo = {
             language,
             attributes: {
-              interactive: interactive === true,
+              interactive: (archive || !interactive) === false,
               style: "display: inline-block",
             },
           };
@@ -319,6 +320,8 @@ function generateArrayOf$outputItems(
         outputExpression,
       )}" data-interactive="${
         derivatives.interactive
+      }" data-archive="${
+        derivatives.archive
       }" data-output-format="${escapeString(
         outputFormat,
       )}"><code>${escapeString(outputFormat)}=${escapeString(

--- a/packages/litvis/src/attributeDerivatives.ts
+++ b/packages/litvis/src/attributeDerivatives.ts
@@ -23,6 +23,8 @@ export function extractAttributeDerivatives(
         ? normalizeExpression(attributesWithMixIns.context)
         : "default",
     outputFormats: [],
+    interactive: true,
+    archive: false,
     outputExpressionsByFormat: {},
     id: attributesWithMixIns.id,
     follows: attributesWithMixIns.follows,
@@ -62,6 +64,9 @@ export function extractAttributeDerivatives(
         case "markdown":
           isLitVis = true;
           addOutputExpressions(result, "m", value);
+          break;
+        case "archive":
+          result.archive = !!value;
           break;
         case "interactive":
           result.interactive = !!value;

--- a/packages/litvis/src/types.ts
+++ b/packages/litvis/src/types.ts
@@ -28,6 +28,7 @@ export interface AttributeDerivatives {
   outputFormats: BlockOutputFormat[];
   outputExpressionsByFormat: { [TKey in OutputFormat]?: string[] };
   interactive?: boolean;
+  archive?: boolean;  
   id?: string;
   follows?: string;
 }


### PR DESCRIPTION
Partially addresses #38  
Enables the use of the archive keyword in codeblocks (only) to prevent interactivity by default.

