### PR TITLE
Rename exported methods in block-attributes and block-info

### DIFF
--- a/packages/block-attributes/src/index.test.ts
+++ b/packages/block-attributes/src/index.test.ts
@@ -1,13 +1,13 @@
 import * as moduleIndex from "./index";
 
 describe("module", () => {
-  it("exports normalize()", () => {
-    expect(typeof moduleIndex.normalize).toEqual("function");
+  it("exports normalizeBlockAttributes()", () => {
+    expect(typeof moduleIndex.normalizeBlockAttributes).toEqual("function");
   });
-  it("exports parse()", () => {
-    expect(typeof moduleIndex.parse).toEqual("function");
+  it("exports parseBlockAttributes()", () => {
+    expect(typeof moduleIndex.parseBlockAttributes).toEqual("function");
   });
-  it("exports stringify()", () => {
-    expect(typeof moduleIndex.stringify).toEqual("function");
+  it("exports stringifyBlockAttributes()", () => {
+    expect(typeof moduleIndex.stringifyBlockAttributes).toEqual("function");
   });
 });

--- a/packages/block-attributes/src/index.ts
+++ b/packages/block-attributes/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./normalize";
-export * from "./parse";
-export * from "./stringify";
+export * from "./normalizeBlockAttributes";
+export * from "./parseBlockAttributes";
+export * from "./stringifyBlockAttributes";
 export * from "./types";

--- a/packages/block-attributes/src/normalizeBlockAttributes.test.ts
+++ b/packages/block-attributes/src/normalizeBlockAttributes.test.ts
@@ -1,13 +1,13 @@
 import { sharedTestCases } from "./__fixtures__/testCases";
-import { normalize } from "./normalize";
+import { normalizeBlockAttributes } from "./normalizeBlockAttributes";
 
-describe("normalize()", () => {
+describe("normalizeBlockAttributes()", () => {
   sharedTestCases.map(({ attributes = null, normalizedAttributes = null }) => {
     if (!attributes || !normalizedAttributes) {
       return;
     }
     test(`works for ${JSON.stringify(attributes)}`, () => {
-      const result = normalize(attributes);
+      const result = normalizeBlockAttributes(attributes);
       expect(result).toEqual(normalizedAttributes);
     });
   });

--- a/packages/block-attributes/src/normalizeBlockAttributes.ts
+++ b/packages/block-attributes/src/normalizeBlockAttributes.ts
@@ -5,7 +5,9 @@ import { BlockAttributes } from "./types";
  * Walks through attribute keys and makes them snakeCase if needed
  * @param attributes
  */
-export const normalize = (attributes: BlockAttributes): BlockAttributes => {
+export const normalizeBlockAttributes = (
+  attributes: BlockAttributes,
+): BlockAttributes => {
   if (typeof attributes !== "object") {
     return {};
   }

--- a/packages/block-attributes/src/parseBlockAttributes.test.ts
+++ b/packages/block-attributes/src/parseBlockAttributes.test.ts
@@ -1,7 +1,7 @@
 import { sharedTestCases } from "./__fixtures__/testCases";
-import { parse } from "./parse";
+import { parseBlockAttributes } from "./parseBlockAttributes";
 
-describe("parse()", () => {
+describe("parseBlockAttributes()", () => {
   sharedTestCases.map(({ raw, attributes }) => {
     if (!raw || !attributes) {
       return;
@@ -9,7 +9,7 @@ describe("parse()", () => {
     const arrayOfTexts = typeof raw === "string" ? [raw] : raw;
     arrayOfTexts.map((text) => {
       test(`works for ${text}`, () => {
-        const result = parse(text!);
+        const result = parseBlockAttributes(text!);
         expect(result).toEqual(attributes);
       });
     });

--- a/packages/block-attributes/src/parseBlockAttributes.ts
+++ b/packages/block-attributes/src/parseBlockAttributes.ts
@@ -127,7 +127,7 @@ const extractArray = (text, start): Node | void => {
  * Parses block attributes
  * @param text e.g. {#identifier .class1 .class2 key1=value1 key2=value2}
  */
-export const parse = (text?: string): BlockAttributes => {
+export const parseBlockAttributes = (text?: string): BlockAttributes => {
   // remove surrounding { } if exist
   let textToParse = (text || "").trim();
   if (textToParse[0] === "{" && textToParse[textToParse.length - 1] === "}") {

--- a/packages/block-attributes/src/stringifyBlockAttributes.test.ts
+++ b/packages/block-attributes/src/stringifyBlockAttributes.test.ts
@@ -1,7 +1,7 @@
 import { sharedTestCases } from "./__fixtures__/testCases";
-import { stringify } from "./stringify";
+import { stringifyBlockAttributes } from "./stringifyBlockAttributes";
 
-describe("stringify()", () => {
+describe("stringifyBlockAttributes()", () => {
   sharedTestCases.map(
     ({
       attributes = null,
@@ -20,11 +20,14 @@ describe("stringify()", () => {
       attributesToTest.map((attrs) => {
         test(`works for ${JSON.stringify(attrs)}`, () => {
           // without curly parentheses
-          const resultWithoutCurlyParentheses = stringify(attrs);
+          const resultWithoutCurlyParentheses = stringifyBlockAttributes(attrs);
           expect(resultWithoutCurlyParentheses).toEqual(stringified);
 
           // with curly parentheses (default)
-          const resultWithCurlyParentheses = stringify(attrs, true);
+          const resultWithCurlyParentheses = stringifyBlockAttributes(
+            attrs,
+            true,
+          );
           expect(resultWithCurlyParentheses).toEqual(`{${stringified}}`);
         });
       });

--- a/packages/block-attributes/src/stringifyBlockAttributes.ts
+++ b/packages/block-attributes/src/stringifyBlockAttributes.ts
@@ -20,7 +20,7 @@ const stringifyArray = (value: any[]) => {
  * Convert attributes as JSON object to attributes as string
  * @param attributes
  */
-export const stringify = (
+export const stringifyBlockAttributes = (
   attributes: BlockAttributes,
   addCurlyBrackets = false,
 ): string => {

--- a/packages/block-info/src/index.test.ts
+++ b/packages/block-info/src/index.test.ts
@@ -1,10 +1,10 @@
 import * as moduleIndex from "./index";
 
 describe("module", () => {
-  it("exports normalize()", () => {
-    expect(typeof moduleIndex.normalize).toEqual("function");
+  it("exports normalizeBlockInfo()", () => {
+    expect(typeof moduleIndex.normalizeBlockInfo).toEqual("function");
   });
-  it("exports parse()", () => {
-    expect(typeof moduleIndex.parse).toEqual("function");
+  it("exports parseBlockInfo()", () => {
+    expect(typeof moduleIndex.parseBlockInfo).toEqual("function");
   });
 });

--- a/packages/block-info/src/index.ts
+++ b/packages/block-info/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./normalize";
-export * from "./parse";
+export * from "./normalizeBlockInfo";
+export * from "./parseBlockInfo";
 export * from "./types";

--- a/packages/block-info/src/normalizeBlockInfo.test.ts
+++ b/packages/block-info/src/normalizeBlockInfo.test.ts
@@ -1,4 +1,4 @@
-import { normalize } from "./normalize";
+import { normalizeBlockInfo } from "./normalizeBlockInfo";
 import { BlockInfo } from "./types";
 
 const testCases: Array<{
@@ -27,7 +27,7 @@ describe("normalize()", () => {
   testCases.map(({ infos, normalizedInfo }) => {
     infos.map((info) => {
       it(`works for ${JSON.stringify(info)}`, () => {
-        const result: object = normalize(info as BlockInfo);
+        const result: object = normalizeBlockInfo(info as BlockInfo);
         expect(result).toEqual(normalizedInfo);
       });
     });

--- a/packages/block-info/src/normalizeBlockInfo.ts
+++ b/packages/block-info/src/normalizeBlockInfo.ts
@@ -1,4 +1,4 @@
-import { normalize as normalizeBlockAttributes } from "block-attributes";
+import { normalizeBlockAttributes } from "block-attributes";
 
 import { BlockInfo } from "./types";
 
@@ -9,7 +9,7 @@ const normalizeLanguage = (language?: string): string => {
   return "";
 };
 
-export const normalize = (blockInfo: BlockInfo): BlockInfo => {
+export const normalizeBlockInfo = (blockInfo: BlockInfo): BlockInfo => {
   const normalizedAttributes = normalizeBlockAttributes(blockInfo.attributes);
   const normalizedLanguage = normalizeLanguage(blockInfo.language);
   if (

--- a/packages/block-info/src/parseBlockInfo.test.ts
+++ b/packages/block-info/src/parseBlockInfo.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "./parse";
+import { parseBlockInfo } from "./parseBlockInfo";
 
 const testCases: Array<{
   info: object;
@@ -27,7 +27,7 @@ describe("parse()", () => {
   testCases.map(({ raw, info }) => {
     raw.map((text) => {
       it(`works for`, () => {
-        const result: object = parse(text);
+        const result: object = parseBlockInfo(text);
         expect(result).toEqual(info);
       });
     });

--- a/packages/block-info/src/parseBlockInfo.ts
+++ b/packages/block-info/src/parseBlockInfo.ts
@@ -1,11 +1,8 @@
-import {
-  BlockAttributes,
-  parse as parseBlockAttributes,
-} from "block-attributes";
+import { BlockAttributes, parseBlockAttributes } from "block-attributes";
 
 import { BlockInfo } from "./types";
 
-export const parse = (raw = ""): BlockInfo => {
+export const parseBlockInfo = (raw = ""): BlockInfo => {
   let language;
   let attributesAsString: string;
   let attributes: BlockAttributes;

--- a/packages/litvis-integration-mume/src/markdownItFeatures/useTripleHatReference.ts
+++ b/packages/litvis-integration-mume/src/markdownItFeatures/useTripleHatReference.ts
@@ -1,4 +1,4 @@
-import { parse as parseBlockInfo } from "block-info";
+import { parseBlockInfo } from "block-info";
 import { Html5Entities } from "html-entities";
 import MarkdownIt from "markdown-it";
 

--- a/packages/litvis/src/document/extractAttributeDerivatives.ts
+++ b/packages/litvis/src/document/extractAttributeDerivatives.ts
@@ -1,4 +1,4 @@
-import { parse as parseBlockInfo } from "block-info";
+import { parseBlockInfo } from "block-info";
 import visit from "unist-util-visit";
 
 import { extractAttributeDerivatives as doExtractAttributeDerivatives } from "../attributeDerivatives";

--- a/packages/narrative-schema-label/src/unist/extractDerivatives.ts
+++ b/packages/narrative-schema-label/src/unist/extractDerivatives.ts
@@ -1,4 +1,4 @@
-import { parse as parseBlockInfo } from "block-info";
+import { parseBlockInfo } from "block-info";
 import _ from "lodash";
 import visit from "unist-util-visit";
 import { VFile } from "vfile";


### PR DESCRIPTION
The goal is to avoid "as" in downstream imports